### PR TITLE
Add JSON as a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
+gemspec
+
 group :development, :test do
   gem 'mocha', :require => false
   gem 'rake',  :require => false
   gem 'rspec', :require => false
 end
-
-gem 'json', :require => false
 
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion, :require => false

--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |s|
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  # Runtime dependencies, but also probably dependencies of requiring projects
-  #s.add_runtime_dependency 'rspec'
+  s.add_dependency 'json'
 end


### PR DESCRIPTION
Ruby 1.9+ has it, but Ruby 1.8 installations generally don't by default.

---

see https://travis-ci.org/domcleal/puppet-dhcp/jobs/45684271