### PR TITLE
Allow custom facts location

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -4,7 +4,7 @@ require 'json'
 module RspecPuppetFacts
 
   def on_supported_os( opts = {} )
-    opts[:hardwaremodels] ||= ['x86_64']
+    opts[:hardwaremodels] ||= RspecPuppetFacts.meta_supported_os
     opts[:supported_os] ||= RspecPuppetFacts.meta_supported_os
     opts[:factslocation] ||= File.expand_path(File.join(File.dirname(__FILE__), "../facts/"))
 
@@ -13,16 +13,18 @@ module RspecPuppetFacts
     opts[:supported_os].map do |os_sup|
       operatingsystem = os_sup['operatingsystem'].downcase
       os_sup['operatingsystemrelease'].map do |operatingsystemmajrelease|
-        opts[:hardwaremodels].each do |hardwaremodel|
-          os = "#{operatingsystem}-#{operatingsystemmajrelease.split(" ")[0]}-#{hardwaremodel}"
-          # TODO: use SemVer here
-          facter_minor_version = Facter.version[0..2]
-          file = "#{opts[:factslocation]}/#{facter_minor_version}/#{os}.facts"
-          # Use File.exists? instead of File.file? here so that we can stub File.file?
-          if ! File.exists?(file)
-            warn "Can't find facts for '#{os}' for facter #{facter_minor_version}, skipping..."
-          else
-            h[os] = JSON.parse(IO.read(file), :symbolize_names => true)
+        opts[:hardwaremodels].map do |hardware_sup|
+          hardware_sup['hardware'].each do |hardware|
+            os = "#{operatingsystem}-#{operatingsystemmajrelease.split(" ")[0]}-#{hardware}"
+            # TODO: use SemVer here
+            facter_minor_version = Facter.version[0..2]
+            file = "#{opts[:factslocation]}/#{facter_minor_version}/#{os}.facts"
+            # Use File.exists? instead of File.file? here so that we can stub File.file?
+            if ! File.exists?(file)
+              warn "Can't find facts for '#{os}' for facter #{facter_minor_version}, skipping..."
+            else
+              h[os] = JSON.parse(IO.read(file), :symbolize_names => true)
+            end
           end
         end
       end
@@ -44,7 +46,7 @@ module RspecPuppetFacts
     end
     metadata['operatingsystem_support']
   end
-
+  
   # @api private
   def self.get_metadata
     if ! File.file?('metadata.json')

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -6,7 +6,7 @@ module RspecPuppetFacts
   def on_supported_os( opts = {} )
     opts[:hardwaremodels] ||= ['x86_64']
     opts[:supported_os] ||= RspecPuppetFacts.meta_supported_os
-    opts[:factslocation] ||= File.expand_path(File.join(File.dirname(__FILE__), "../facts/#{facter_minor_version}/#{os}.facts"))
+    opts[:factslocation] ||= File.expand_path(File.join(File.dirname(__FILE__), "../facts/"))
 
     h = {}
 
@@ -17,7 +17,7 @@ module RspecPuppetFacts
           os = "#{operatingsystem}-#{operatingsystemmajrelease.split(" ")[0]}-#{hardwaremodel}"
           # TODO: use SemVer here
           facter_minor_version = Facter.version[0..2]
-          file = :factslocation
+          file = "#{opts[:factslocation]}/#{facter_minor_version}/#{os}.facts"
           # Use File.exists? instead of File.file? here so that we can stub File.file?
           if ! File.exists?(file)
             warn "Can't find facts for '#{os}' for facter #{facter_minor_version}, skipping..."

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -6,6 +6,7 @@ module RspecPuppetFacts
   def on_supported_os( opts = {} )
     opts[:hardwaremodels] ||= ['x86_64']
     opts[:supported_os] ||= RspecPuppetFacts.meta_supported_os
+    opts[:factslocation] ||= File.expand_path(File.join(File.dirname(__FILE__), "../facts/#{facter_minor_version}/#{os}.facts"))
 
     h = {}
 
@@ -16,7 +17,7 @@ module RspecPuppetFacts
           os = "#{operatingsystem}-#{operatingsystemmajrelease.split(" ")[0]}-#{hardwaremodel}"
           # TODO: use SemVer here
           facter_minor_version = Facter.version[0..2]
-          file = File.expand_path(File.join(File.dirname(__FILE__), "../facts/#{facter_minor_version}/#{os}.facts"))
+          file = :factslocation
           # Use File.exists? instead of File.file? here so that we can stub File.file?
           if ! File.exists?(file)
             warn "Can't find facts for '#{os}' for facter #{facter_minor_version}, skipping..."

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -58,7 +58,9 @@ end
 
 RSpec.configure do |c|
   begin
-    c.formatter = 'NyanCatFormatter' if Date.today.strftime('%m%d') == '0401'
+    #c.formatter = 'NyanCatFormatter' if Date.today.strftime('%m%d') == '0401'
+    #Love for NyanCat
+    c.formatter = 'NyanCatFormatter'
   rescue LoadError
   end
 end

--- a/spec/fixtures/metadata.json
+++ b/spec/fixtures/metadata.json
@@ -17,6 +17,10 @@
       "operatingsystemrelease": [
         "6",
         "7"
+      ],
+      "hardware": [ 
+	"x86_64",
+	"i386"
       ]
     },
     {


### PR DESCRIPTION
Hello, we like your version of this module, but we found that we needed facts which you didn't have (Solaris sparc, AIX power pc).  We'd like to keep tracking the additions you make, would you consider this patch or provide a way to choose an alternate facts location?