### PR TITLE
Allow fetching or excluding facts with additional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,40 @@ describe 'myclass' do
 end
 ```
 
+You can easily reduce the calls to FacterDB by using `only_os` and` exclude_os`
+parameters. This can help reducing the time of the tests.
+
+Both arguments take a string of an array of _distro-version-hardwaremodel_ value:
+
+* ubuntu-12-x86_64
+* redhat-7-x86_64
+
+```ruby
+require 'spec_helper'
+
+describe 'myclass' do
+
+  on_supported_os({:only_os => 'ubuntu-12-x86_64'}).each do |os, facts|
+    context "on #{os}" do
+      it { is_expected.to compile.with_all_deps }
+      ...
+    end
+  end
+  on_supported_os({:only_os => ['ubuntu-12-x86_64', 'ubuntu-16-x86_64']}).each do |os, facts|
+    context "on #{os}" do
+      it { is_expected.to compile.with_all_deps }
+      ...
+    end
+  end
+  on_supported_os({:exclude_os => 'ubuntu-16-x86_64'}).each do |os, facts|
+    context "on #{os}" do
+      it { is_expected.to compile.with_all_deps }
+      ...
+    end
+  end
+end
+```
+
 Usage
 -----
 

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -8,6 +8,8 @@ module RspecPuppetFacts
   def on_supported_os( opts = {} )
     opts[:hardwaremodels] ||= ['x86_64']
     opts[:supported_os] ||= RspecPuppetFacts.meta_supported_os
+    opts[:only_os] ||= Array.new
+    opts[:excluded_os] ||= Array.new
 
     filter = []
     opts[:supported_os].map do |os_sup|
@@ -21,6 +23,11 @@ module RspecPuppetFacts
               hardwaremodel = 'i86pc'
             end
 
+            osmajorreleaseshorcut = operatingsystemmajrelease.split(/[\s\.]/).first
+            pretty_name = "#{os_sup['operatingsystem']}-#{osmajorreleaseshorcut}-#{hardwaremodel}".downcase
+            next unless Array(opts[:only_os]).length == 0 or opts[:only_os].include?(pretty_name)
+            next if Array(opts[:excluded_os]).include?(pretty_name)
+
             filter << {
               :facterversion          => "/^#{Facter.version[0..2]}/",
               :operatingsystem        => os_sup['operatingsystem'],
@@ -31,6 +38,10 @@ module RspecPuppetFacts
         end
       else
         opts[:hardwaremodels].each do |hardwaremodel|
+          pretty_name = "#{os_sup['operatingsystem']}-#{hardwaremodel}".downcase
+          next unless Array(opts[:only_os]).length == 0 or opts[:only_os].include?(pretty_name)
+          next if Array(opts[:excluded_os]).include?(pretty_name)
+
           filter << {
             :facterversion   => "/^#{Facter.version[0..2]}/",
             :operatingsystem => os_sup['operatingsystem'],

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -95,6 +95,310 @@ describe 'RspecPuppetFacts' do
       end
     end
 
+    context 'When specifying supported_os and a string as only_os' do
+      subject {
+        on_supported_os(
+          {
+            :supported_os => [
+              {
+                "operatingsystem" => "Debian",
+                "operatingsystemrelease" => [
+                  "6",
+                  "7"
+                ]
+              },
+              {
+                "operatingsystem" => "RedHat",
+                "operatingsystemrelease" => [
+                  "5",
+                  "6"
+                ]
+              }
+            ],
+            :only_os => 'debian-6-x86_64'
+          }
+        )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 1 element' do
+        expect(subject.size).to eq 1
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq [
+          'debian-6-x86_64',
+        ]
+      end
+    end
+
+    context 'When specifying supported_os and an array of 1 element as only_os' do
+      subject {
+        on_supported_os(
+          {
+            :supported_os => [
+              {
+                "operatingsystem" => "Debian",
+                "operatingsystemrelease" => [
+                  "6",
+                  "7"
+                ]
+              },
+              {
+                "operatingsystem" => "RedHat",
+                "operatingsystemrelease" => [
+                  "5",
+                  "6"
+                ]
+              }
+            ],
+            :only_os => ['debian-6-x86_64']
+          }
+        )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 1 element' do
+        expect(subject.size).to eq 1
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq [
+          'debian-6-x86_64',
+        ]
+      end
+    end
+
+    context 'When specifying supported_os and an array of 2 elements as only_os' do
+      subject {
+        on_supported_os(
+          {
+            :supported_os => [
+              {
+                "operatingsystem" => "Debian",
+                "operatingsystemrelease" => [
+                  "6",
+                  "7"
+                ]
+              },
+              {
+                "operatingsystem" => "RedHat",
+                "operatingsystemrelease" => [
+                  "5",
+                  "6"
+                ]
+              }
+            ],
+            :only_os => ['debian-6-x86_64', 'redhat-5-x86_64']
+          }
+        )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 2 elements' do
+        expect(subject.size).to eq 2
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq [
+          'debian-6-x86_64',
+          'redhat-5-x86_64',
+        ]
+      end
+    end
+
+    context 'When specifying supported_os and an array of 2 elements of the same osfamily as only_os' do
+      subject {
+        on_supported_os(
+          {
+            :supported_os => [
+              {
+                "operatingsystem" => "Debian",
+                "operatingsystemrelease" => [
+                  "6",
+                  "7"
+                ]
+              },
+              {
+                "operatingsystem" => "RedHat",
+                "operatingsystemrelease" => [
+                  "5",
+                  "6"
+                ]
+              }
+            ],
+            :only_os => ['redhat-6-x86_64', 'redhat-5-x86_64']
+          }
+        )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 2 elements' do
+        expect(subject.size).to eq 2
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq [
+          'redhat-5-x86_64',
+          'redhat-6-x86_64',
+        ]
+      end
+    end
+
+    context 'When specifying supported_os and a string as excluded_os' do
+      subject {
+        on_supported_os(
+          {
+            :supported_os => [
+              {
+                "operatingsystem" => "Debian",
+                "operatingsystemrelease" => [
+                  "6",
+                  "7"
+                ]
+              },
+              {
+                "operatingsystem" => "RedHat",
+                "operatingsystemrelease" => [
+                  "5",
+                  "6"
+                ]
+              }
+            ],
+            :excluded_os => 'debian-6-x86_64'
+          }
+        )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 3 elements' do
+        expect(subject.size).to eq 3
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq [
+          'debian-7-x86_64',
+          'redhat-5-x86_64',
+          'redhat-6-x86_64',
+        ]
+      end
+    end
+
+    context 'When specifying supported_os and an array of 1 element as excluded_os' do
+      subject {
+        on_supported_os(
+          {
+            :supported_os => [
+              {
+                "operatingsystem" => "Debian",
+                "operatingsystemrelease" => [
+                  "6",
+                  "7"
+                ]
+              },
+              {
+                "operatingsystem" => "RedHat",
+                "operatingsystemrelease" => [
+                  "5",
+                  "6"
+                ]
+              }
+            ],
+            :excluded_os => ['debian-6-x86_64']
+          }
+        )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 3 elements' do
+        expect(subject.size).to eq 3
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq [
+          'debian-7-x86_64',
+          'redhat-5-x86_64',
+          'redhat-6-x86_64',
+        ]
+      end
+    end
+
+    context 'When specifying supported_os and an array of 2 elements as excluded_os' do
+      subject {
+        on_supported_os(
+          {
+            :supported_os => [
+              {
+                "operatingsystem" => "Debian",
+                "operatingsystemrelease" => [
+                  "6",
+                  "7"
+                ]
+              },
+              {
+                "operatingsystem" => "RedHat",
+                "operatingsystemrelease" => [
+                  "5",
+                  "6"
+                ]
+              }
+            ],
+            :excluded_os => ['debian-6-x86_64', 'redhat-5-x86_64']
+          }
+        )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 2 elements' do
+        expect(subject.size).to eq 2
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq [
+          'debian-7-x86_64',
+          'redhat-6-x86_64',
+        ]
+      end
+    end
+
+    context 'When specifying supported_os and an array of 2 elements of the same osfamily as excluded_os' do
+      subject {
+        on_supported_os(
+          {
+            :supported_os => [
+              {
+                "operatingsystem" => "Debian",
+                "operatingsystemrelease" => [
+                  "6",
+                  "7"
+                ]
+              },
+              {
+                "operatingsystem" => "RedHat",
+                "operatingsystemrelease" => [
+                  "5",
+                  "6"
+                ]
+              }
+            ],
+            :excluded_os => ['redhat-6-x86_64', 'redhat-5-x86_64']
+          }
+        )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 2 elements' do
+        expect(subject.size).to eq 2
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq [
+          'debian-6-x86_64',
+          'debian-7-x86_64',
+        ]
+      end
+    end
+
     context 'When testing FreeBSD 10' do
       subject {
         on_supported_os(


### PR DESCRIPTION
This commit allows to pass 2 additional parameters to on_supported_os:
only_os and excluded_os.

They are Arrays of pretty OS names (freebsd-10-amd64, centos-7-x86_64).

That would make possible for third parties to easily exclude the
fetching of some facts, speeding tests.