### PR TITLE
Add missing dependency on mcollective-client to fix spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gemspec
 
+gem 'mcollective-client',      :require => false
+
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion, :require => false
 else


### PR DESCRIPTION
Previous addition for mco_version fact broke unit tests for this project and all projects dependent on rspec-puppet-facts that did not explicitly ask for the "mcollective-client" gem.

Fix this issue with this change.