### PR TITLE
Add the env variable OS filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Gemfile.lock
 .bundle/
 coverage/
 .idea
+doc
+.yardoc

--- a/README.md
+++ b/README.md
@@ -277,6 +277,18 @@ require 'rspec-puppet-facts'
 include RspecPuppetFacts
 ```
 
+Run the tests:
+
+```bash
+rake spec
+```
+
+Run the tests only on some of the facts sets:
+
+```bash
+SPEC_FACTS_OS='ubuntu-14' rake spec
+```
+
 Finaly, Add some `facter` version to test in your .travis.yml
 
 ```yaml

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 begin
     require 'rspec/core/rake_task'
-      RSpec::Core::RakeTask.new(:spec)
+    require 'yard'
+    RSpec::Core::RakeTask.new(:spec)
+    YARD::Rake::YardocTask.new
 rescue LoadError
 end

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -8,6 +8,7 @@ module RspecPuppetFacts
 
   def on_supported_os( opts = {} )
     opts[:hardwaremodels] ||= ['x86_64']
+    opts[:hardwaremodels] = [opts[:hardwaremodels]] unless opts[:hardwaremodels].is_a? Array
     opts[:supported_os] ||= RspecPuppetFacts.meta_supported_os
 
     filter = []
@@ -27,7 +28,7 @@ module RspecPuppetFacts
             filter << {
               :facterversion          => "/^#{Facter.version[0..2]}/",
               :operatingsystem        => os_sup['operatingsystem'],
-              :operatingsystemrelease => "/^#{operatingsystemmajrelease.split(" ")[0]}/",
+              :operatingsystemrelease => "/^#{operatingsystemmajrelease.split(' ')[0]}/",
               :hardwaremodel          => hardwaremodel,
             }
           end
@@ -43,39 +44,70 @@ module RspecPuppetFacts
       end
     end
 
-    h = {}
-    FacterDB::get_facts(filter).map do |facts|
-      facts.merge!({
+    received_facts = FacterDB::get_facts(filter)
+    unless received_facts.any?
+      RspecPuppetFacts.warning "No facts were found in the FacterDB for: #{filter.inspect}"
+      return {}
+    end
+
+    os_facts_hash = {}
+    received_facts.map do |facts|
+      os = "#{facts[:operatingsystem].downcase}-#{facts[:operatingsystemrelease].split('.')[0]}-#{facts[:hardwaremodel]}"
+      facts.merge! RspecPuppetFacts.common_facts
+      os_facts_hash[os] = facts
+    end
+    os_facts_hash
+  end
+
+  # These facts are common for all OS'es and will be
+  # added to the facts retrieved from the FacterDB
+  # @api private
+  # @return [Hash <Symbol => String>]
+  def self.common_facts
+    return @common_facts if @common_facts
+    @common_facts = {
         :mco_version   => MCollective::VERSION,
         :puppetversion => Puppet.version,
-        :rubysitedir   => RbConfig::CONFIG["sitelibdir"],
+        :rubysitedir   => RbConfig::CONFIG['sitelibdir'],
         :rubyversion   => RUBY_VERSION,
-      })
-      facts[:augeasversion] = Augeas.open(nil, nil, Augeas::NO_MODL_AUTOLOAD).get('/augeas/version') if Puppet.features.augeas?
-      h["#{facts[:operatingsystem].downcase}-#{facts[:operatingsystemrelease].split('.')[0]}-#{facts[:hardwaremodel]}"] = facts
+    }
+    if Puppet.features.augeas?
+      @common_facts[:augeasversion] = Augeas.open(nil, nil, Augeas::NO_MODL_AUTOLOAD).get('/augeas/version')
     end
-    h
+    @common_facts
   end
 
   # @api private
   def self.meta_supported_os
-    @meta_supported_os ||= get_meta_supported_os
-  end
-
-  # @api private
-  def self.get_meta_supported_os
-    metadata = get_metadata
-    if metadata['operatingsystem_support'].nil?
-      fail StandardError, "Unknown operatingsystem support"
+    unless metadata['operatingsystem_support'].is_a? Array
+      fail StandardError, 'Unknown operatingsystem support in the metadata file!'
     end
     metadata['operatingsystem_support']
   end
 
   # @api private
-  def self.get_metadata
-    if ! File.file?('metadata.json')
+  def self.metadata
+    return @metadata if @metadata
+    unless File.file? metadata_file
       fail StandardError, "Can't find metadata.json... dunno why"
     end
-    JSON.parse(File.read('metadata.json'))
+    content = File.read metadata_file
+    @metadata = JSON.parse content
+  end
+
+  # @api private
+  def self.metadata_file
+    'metadata.json'
+  end
+
+  # @api private
+  def self.warning(message)
+    STDERR.puts message
+  end
+
+  # @api private
+  def self.reset
+    @common_facts = nil
+    @metadata = nil
   end
 end

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -13,6 +13,12 @@ module RspecPuppetFacts
   # OS names and facts can be used in the Puppet RSpec tests
   # to run the examples against all supported facts combinations.
   #
+  # The list of received OS facts can also be filtered by the SPEC_FACTS_OS
+  # environment variable. For example, if the variable is set to "debian"
+  # only the OS names which start with "debian" will be returned. It allows a
+  # user to quickly run the tests only on a single facts set without any
+  # file modifications.
+  #
   # @return [Hash <String => Hash>]
   # @param [Hash] opts
   # @option opts [String,Array<String>] :hardwaremodels The OS architecture names, i.e. x86_64
@@ -66,10 +72,21 @@ module RspecPuppetFacts
     os_facts_hash = {}
     received_facts.map do |facts|
       os = "#{facts[:operatingsystem].downcase}-#{facts[:operatingsystemrelease].split('.')[0]}-#{facts[:hardwaremodel]}"
+      next unless os.start_with? RspecPuppetFacts.spec_facts_os_filter if RspecPuppetFacts.spec_facts_os_filter
       facts.merge! RspecPuppetFacts.common_facts
       os_facts_hash[os] = facts
     end
     os_facts_hash
+  end
+
+  # If provided this filter can be used to limit the set
+  # of retrieved facts only to the matched OS names.
+  # The value is being taken from the SPEC_FACTS_OS environment
+  # variable and 
+  # @return [nil,String]
+  # @api private
+  def self.spec_facts_os_filter
+    ENV['SPEC_FACTS_OS']
   end
 
   # These facts are common for all OS'es and will be

--- a/lib/rspec-puppet-facts/version.rb
+++ b/lib/rspec-puppet-facts/version.rb
@@ -1,5 +1,7 @@
 module RspecPuppetFacts
+  # This module contains the current version constant
   module Version
+    # The current version of this gem
     STRING = '1.5.0'
   end
 end

--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'yard'
   s.add_runtime_dependency 'puppet'
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'facter'

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -54,6 +54,15 @@ describe RspecPuppetFacts do
               redhat-7-x86_64
             )
           end
+
+          it 'should be able to filter the received OS facts' do
+            allow(RspecPuppetFacts).to receive(:spec_facts_os_filter).and_return('redhat')
+            expect(subject.keys.sort).to eq %w(
+              redhat-5-x86_64
+              redhat-6-x86_64
+              redhat-7-x86_64
+            )
+          end
         end
 
         context 'With a broken metadata.json' do
@@ -119,6 +128,14 @@ describe RspecPuppetFacts do
         expect(subject.keys.sort).to eq %w(
           debian-6-x86_64
           debian-7-x86_64
+          redhat-5-x86_64
+          redhat-6-x86_64
+        )
+      end
+
+      it 'should be able to filter the received OS facts' do
+        allow(RspecPuppetFacts).to receive(:spec_facts_os_filter).and_return('redhat')
+        expect(subject.keys.sort).to eq %w(
           redhat-5-x86_64
           redhat-6-x86_64
         )


### PR DESCRIPTION
Fefactoring and cleanups
* Cleanup the methods and some minor
  refactoring without introducing any
  new featutres
* Add inline YARD documentation
  and yard doc actions to the Rakefile
* Refactoring and improvements of the
  RSpec tests

Add the OS filter support
If the SPEC_FACTS_OS variable is set only the matching OS'es
will be tested.

Example:
> SPEC_FACTS_OS='ubuntu-14' rake spec

It will test only on the Trusty Ubuntu even if there are more
supported OS'es in the metadata file.