### PR TITLE
Support custom facts defined by spec_helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,8 @@ else
   gem 'facter', :require => false
 end
 
-gem 'json', '~> 1.0', {"platforms"=>["ruby_18", "ruby_19"]}
+platforms :ruby_18, :ruby_19 do
+  gem 'json', '~> 1.0'
+  gem 'json_pure', '~> 1.0'
+  gem 'tins', '~> 1.6.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ if facterversion = ENV['FACTER_GEM_VERSION']
 else
   gem 'facter', :require => false
 end
+
+gem 'json', '~> 1.0', {"platforms"=>["ruby_18", "ruby_19"]}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ describe 'myclass' do
         :operatingsystemmajrelease => '7',
         ...
       }
-      
+
       it { is_expected.to compile.with_all_deps }
       ...
     end
@@ -43,12 +43,12 @@ describe 'myclass' do
         :operatingsystemmajrelease => '6',
         ...
       }
-      
+
       it { is_expected.to compile.with_all_deps }
       ...
     end
   end
-  
+
   ...
 end
 ```
@@ -65,7 +65,7 @@ describe 'myclass' do
       let(:facts) do
         facts
       end
-      
+
       it { is_expected.to compile.with_all_deps }
       ...
       case facts[:osfamily]
@@ -193,9 +193,9 @@ describe Puppet::Parser::Functions.function(:myfunction) do
         end
       end
     end
-    
+
     ...
-    
+
   end
 end
 ```
@@ -230,7 +230,7 @@ describe 'myclass' do
       let(:facts) do
         facts
       end
-      
+
       it { is_expected.to compile.with_all_deps }
       ...
     end
@@ -240,6 +240,8 @@ end
 
 Append some facts:
 ------------------
+
+1. In your spec
 
 ```ruby
 require 'spec_helper'
@@ -253,13 +255,37 @@ describe 'myclass' do
           :foo => 'bar',
         })
       end
-      
+
       it { is_expected.to compile.with_all_deps }
       ...
     end
   end
 end
 ```
+
+2. In your `spec_helper.rb`
+  * Simple:
+
+    ```ruby
+    add_custom_fact 'foo', 'bar'
+    ```
+
+  * Confine to an OS:
+
+    ```ruby
+    add_custom_fact :root_home, '/root', :confine => 'redhat-7-x86_64'
+    ```
+
+  * Exclude an OS:
+
+    ```ruby
+    add_custom_fact :root_home, '/root', :exclude => 'redhat-7-x86_64'
+    ```
+  * Call a proc to get a value:
+
+    ```ruby
+    add_custom_fact :root_home, ->(_os,facts) { "/tmp/#{facts['hostname']}"
+    ```
 
 Usage
 -----

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -372,6 +372,50 @@ describe RspecPuppetFacts do
     end
   end
 
+  context '#add_custom_fact' do
+    subject {
+      on_supported_os(
+        {
+          :supported_os => [
+            {
+              "operatingsystem" => "RedHat",
+              "operatingsystemrelease" => [
+                "6",
+                "7"
+              ]
+            }
+          ]
+        }
+      )
+    }
+
+    before(:each) do
+      RspecPuppetFacts.reset
+    end
+
+    it 'adds a simple fact and value' do
+      add_custom_fact 'root_home', '/root'
+      expect(subject['redhat-7-x86_64']['root_home']).to eq '/root'
+    end
+
+    it 'confines a fact to a particular operating system' do
+      add_custom_fact 'root_home', '/root', :confine => 'redhat-7-x86_64'
+      expect(subject['redhat-7-x86_64']['root_home']).to eq '/root'
+      expect(subject['redhat-6-x86_64']['root_home']).to be_nil
+    end
+
+    it 'excludes a fact from a particular operating system' do
+      add_custom_fact 'root_home', '/root', :exclude => 'redhat-7-x86_64'
+      expect(subject['redhat-7-x86_64']['root_home']).to be_nil
+      expect(subject['redhat-6-x86_64']['root_home']).to eq '/root'
+    end
+
+    it 'takes a proc as a value' do
+      add_custom_fact 'root_home', ->(_os, _facts) { '/root' }
+      expect(subject['redhat-7-x86_64']['root_home']).to eq '/root'
+    end
+  end
+
   context '#misc' do
     it 'should have a common facts structure' do
       RspecPuppetFacts.reset


### PR DESCRIPTION
Fixes #14. Allows users to register additional custom facts.

Simple:
`add_custom_fact :root_home, '/root'`

Confine to an OS:
`add_custom_fact :root_home, '/root', :confine => 'redhat-7-x86_64'`

Exclude an OS:
`add_custom_fact :root_home, '/root', :exclude => 'redhat-7-x86_64'`

Call a proc to get a value:
`add_custom_fact :root_home, ->(_os,facts) { "/tmp/#{facts['hostname']}"`