### PR TITLE
Ignore case when choosing H/W models

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -36,11 +36,11 @@ module RspecPuppetFacts
         os_sup['operatingsystemrelease'].map do |operatingsystemmajrelease|
           opts[:hardwaremodels].each do |hardwaremodel|
 
-            if os_sup['operatingsystem'] =~ /BSD/
+            if os_sup['operatingsystem'] =~ /BSD/i
               hardwaremodel = 'amd64'
-            elsif os_sup['operatingsystem'] =~ /Solaris/
+            elsif os_sup['operatingsystem'] =~ /Solaris/i
               hardwaremodel = 'i86pc'
-            elsif os_sup['operatingsystem'] =~ /windows/
+            elsif os_sup['operatingsystem'] =~ /Windows/i
               hardwaremodel = 'x64'
             end
 


### PR DESCRIPTION
metadata.json's operating system names are not case-sensitive, so this
should not be either.