### PR TITLE
Fix wrong example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ describe 'myclass::debian' do
   }
 
   on_supported_os(test_on).each do |os, facts|
+    let (:facts) { facts }
     it { is_expected.to compile.with_all_deps }
   end
 end


### PR DESCRIPTION
It's necessary to make facts available to the example by using let, thus the change is actually making the example in the README work properly.

Closes: #51