### PR TITLE
Improve windows support

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -62,6 +62,7 @@ module RspecPuppetFacts
             elsif os_sup['operatingsystem'] =~ /Windows/i
               hardwaremodel = 'x64'
               os_sup['operatingsystem'] = os_sup['operatingsystem'].downcase
+              operatingsystemmajrelease = operatingsystemmajrelease[/\A(?:Server )?(.+)/i, 1]
             end
 
             filter << {

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -61,6 +61,7 @@ module RspecPuppetFacts
               hardwaremodel = 'i86pc'
             elsif os_sup['operatingsystem'] =~ /Windows/i
               hardwaremodel = 'x64'
+              os_sup['operatingsystem'] = os_sup['operatingsystem'].downcase
             end
 
             filter << {

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -55,6 +55,7 @@ module RspecPuppetFacts
         os_sup['operatingsystemrelease'].map do |operatingsystemmajrelease|
           opts[:hardwaremodels].each do |hardwaremodel|
 
+            os_release_filter = "/^#{operatingsystemmajrelease.split(' ')[0]}/"
             if os_sup['operatingsystem'] =~ /BSD/i
               hardwaremodel = 'amd64'
             elsif os_sup['operatingsystem'] =~ /Solaris/i
@@ -64,15 +65,18 @@ module RspecPuppetFacts
               os_sup['operatingsystem'] = os_sup['operatingsystem'].downcase
               operatingsystemmajrelease = operatingsystemmajrelease[/\A(?:Server )?(.+)/i, 1]
 
+              # force quoting because windows releases can contain spaces
+              os_release_filter = "\"#{operatingsystemmajrelease}\""
+
               if operatingsystemmajrelease == '2016' && Puppet::Util::Package.versioncmp(version, '3.4') < 0
-                operatingsystemmajrelease = '/^10\\.0\\./'
+                os_release_filter = '/^10\\.0\\./'
               end
             end
 
             filter << {
                 :facterversion          => facter_version_filter,
                 :operatingsystem        => os_sup['operatingsystem'],
-                :operatingsystemrelease => "/^#{operatingsystemmajrelease.split(' ')[0]}/",
+                :operatingsystemrelease => os_release_filter,
                 :hardwaremodel          => hardwaremodel,
             }
           end

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -63,6 +63,10 @@ module RspecPuppetFacts
               hardwaremodel = 'x64'
               os_sup['operatingsystem'] = os_sup['operatingsystem'].downcase
               operatingsystemmajrelease = operatingsystemmajrelease[/\A(?:Server )?(.+)/i, 1]
+
+              if operatingsystemmajrelease == '2016' && Puppet::Util::Package.versioncmp(version, '3.4') < 0
+                operatingsystemmajrelease = '/^10\\.0\\./'
+              end
             end
 
             filter << {
@@ -105,6 +109,8 @@ module RspecPuppetFacts
         operatingsystemmajrelease = facts[:operatingsystemrelease].split('.')[0..1].join('.')
       elsif facts[:operatingsystem] == 'OpenBSD'
         operatingsystemmajrelease = facts[:operatingsystemrelease]
+      elsif facts[:operatingsystem] == 'windows' && facts[:operatingsystemrelease].start_with?('10.0.')
+        operatingsystemmajrelease = '2016'
       else
         if facts[:operatingsystemmajrelease].nil?
           operatingsystemmajrelease = facts[:operatingsystemrelease].split('.')[0]

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -265,31 +265,50 @@ describe RspecPuppetFacts do
       end
     end
 
-    context 'When testing Windows 7', :if => Facter.version.to_f >= 2.4 do
-      subject {
+    context 'When testing Windows', :if => Facter.version.to_f >= 2.4 do
+      subject do
         on_supported_os(
           {
             :supported_os => [
               {
-                "operatingsystem" => "windows",
-                "operatingsystemrelease" => [
-                  "7",
-                ],
-              },
+                'operatingsystem'        => 'Windows',
+                'operatingsystemrelease' => release,
+              }
             ],
           }
         )
-      }
-      it 'should return a hash' do
-        expect(subject.class).to eq Hash
       end
-      it 'should have 1 elements' do
-        expect(subject.size).to eq 1
+
+      context 'with a standard release' do
+        let(:release) { ['7'] }
+
+        it { is_expected.to be_a(Hash) }
+        it { is_expected.to have_attributes(:size => 1) }
+        it { is_expected.to include('windows-7-x64' => an_instance_of(Hash)) }
       end
-      it 'should return supported OS' do
-        expect(subject.keys.sort).to eq [
-          'windows-7-x64',
-        ]
+
+      context 'with a revision release' do
+        let(:release) { ['2012 R2'] }
+
+        it { is_expected.to be_a(Hash) }
+        it { is_expected.to have_attributes(:size => 1) }
+        it { is_expected.to include('windows-2012 R2-x64' => an_instance_of(Hash)) }
+      end
+
+      context 'with a Server prefixed release' do
+        let(:release) { ['Server 2012'] }
+
+        it { is_expected.to be_a(Hash) }
+        it { is_expected.to have_attributes(:size => 1) }
+        it { is_expected.to include('windows-2012-x64' => an_instance_of(Hash)) }
+      end
+
+      context 'with a 2016 release' do
+        let(:release) { ['2016'] }
+
+        it { is_expected.to be_a(Hash) }
+        it { is_expected.to have_attributes(:size => 1) }
+        it { is_expected.to include('windows-2016-x64' => an_instance_of(Hash)) }
       end
     end
 


### PR DESCRIPTION
This PR addresses some common problems when trying to retrieve facts for Windows.

 * Downcase the `operatingsystem` value if it matches `/windows/i` to match Facter's output
 * Strip `Server` prefix from the release name/number if present
 * Munge the output when requesting facts for win-2016 && facter < 3.4 as the release name is not detected properly (Facter just returns the `kernelrelease` value)
 * Takes into account spaces for windows release names when building the filter hash so that if requesting the facts for `2012 R2` (for example) it does not also return the facts for `2012`.

The build errors should clear up once #57 is merged