### PR TITLE
hardwaremodel output changed on Windows with Facter 3.x

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -61,7 +61,7 @@ module RspecPuppetFacts
             elsif os_sup['operatingsystem'] =~ /Solaris/i
               hardwaremodel = 'i86pc'
             elsif os_sup['operatingsystem'] =~ /Windows/i
-              hardwaremodel = 'x64'
+              hardwaremodel = version =~ /^[12]\./ ? 'x64' : 'x86_64'
               os_sup['operatingsystem'] = os_sup['operatingsystem'].downcase
               operatingsystemmajrelease = operatingsystemmajrelease[/\A(?:Server )?(.+)/i, 1]
 


### PR DESCRIPTION
On Facter 1.x and 2.x, the `hardwaremodel` fact on Windows would return
`x32` or `x64`, but on Facter 3.x this has changed to `i386` and
`x86_64` so the filter needs to be changed to take this into account.