### PR TITLE
Adds docs for using custom external facts

### DIFF
--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet'
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'facter'
-  s.add_runtime_dependency 'facterdb', '>= 0.3.0'
+  s.add_runtime_dependency 'facterdb', '>= 0.5.0'
   s.add_runtime_dependency 'mcollective-client'
 end


### PR DESCRIPTION
  * before facterdb 0.4.0 there was no way to supply custom fact sets
    to facterdb.  This commit bumps the version of facterdb and
    adds documentation for using external facts with rspec-puppet-facts.