### PR TITLE
Add AIX support

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -60,6 +60,13 @@ module RspecPuppetFacts
               hardwaremodel = 'amd64'
             elsif os_sup['operatingsystem'] =~ /Solaris/i
               hardwaremodel = 'i86pc'
+            elsif os_sup['operatingsystem'] =~ /AIX/i
+              hardwaremodel = '/^IBM,.*/'
+              os_release_filter = if operatingsystemmajrelease =~ /\A(\d+)\.(\d+)\Z/
+                                    "/^#{$~[1]}#{$~[2]}00-/"
+                                  else
+                                    "/^#{operatingsystemmajrelease}-/"
+                                  end
             elsif os_sup['operatingsystem'] =~ /Windows/i
               hardwaremodel = version =~ /^[12]\./ ? 'x64' : 'x86_64'
               os_sup['operatingsystem'] = os_sup['operatingsystem'].downcase

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -265,6 +265,35 @@ describe RspecPuppetFacts do
       end
     end
 
+    context 'When testing AIX 7.1', :if => Facter.version.to_f >= 2.0 do
+      subject {
+        on_supported_os(
+            {
+                :supported_os => [
+                    {
+                        "operatingsystem" => "AIX",
+                        "operatingsystemrelease" => [
+                            "7.1",
+                        ],
+                    },
+                ],
+                :facterversion => '3.9'
+            }
+        )
+      }
+      it 'should return a hash' do
+        expect(subject.class).to eq Hash
+      end
+      it 'should have 1 elements' do
+        expect(subject.size).to eq 1
+      end
+      it 'should return supported OS' do
+        expect(subject.keys.sort).to eq %w(
+          aix-7100-IBM,8284-22A
+        )
+      end
+    end
+
     context 'When testing Windows', :if => Facter.version.to_f >= 2.4 do
       subject do
         on_supported_os(

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -265,7 +265,7 @@ describe RspecPuppetFacts do
       end
     end
 
-    context 'When testing AIX 7.1', :if => Facter.version.to_f >= 2.0 do
+    context 'When testing AIX 7.1' do
       subject {
         on_supported_os(
             {
@@ -273,7 +273,7 @@ describe RspecPuppetFacts do
                     {
                         "operatingsystem" => "AIX",
                         "operatingsystemrelease" => [
-                            "7.1",
+                            "7.1", "7100"
                         ],
                     },
                 ],
@@ -288,6 +288,8 @@ describe RspecPuppetFacts do
         expect(subject.size).to eq 1
       end
       it 'should return supported OS' do
+        # NOTE: See FACT-1827 for details on the IBM,8284-22A part
+        # That has to match whatever hardware generated the facts file.
         expect(subject.keys.sort).to eq %w(
           aix-7100-IBM,8284-22A
         )


### PR DESCRIPTION
I had to add AIX *legacy* facts to support testing in AIX 7.1. Also had to adjust the "major version" to 7100. Note this requires the not-yet-released facterdb with my commit: https://github.com/camptocamp/facterdb/commit/dabc768817de761e6eddc1b3925724fa5fa95e24