### PR TITLE
Downgrade facter versions per OS

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -85,7 +85,6 @@ module RspecPuppetFacts
             end
 
             filter << {
-                :facterversion          => facter_version_filter,
                 :operatingsystem        => os_sup['operatingsystem'],
                 :operatingsystemrelease => os_release_filter,
                 :hardwaremodel          => hardwaremodel,
@@ -95,7 +94,6 @@ module RspecPuppetFacts
       else
         opts[:hardwaremodels].each do |hardwaremodel|
           filter << {
-              :facterversion   => facter_version_filter,
               :operatingsystem => os_sup['operatingsystem'],
               :hardwaremodel   => hardwaremodel,
           }
@@ -103,18 +101,37 @@ module RspecPuppetFacts
       end
     end
 
+    # FacterDB may have newer versions of facter data for which it contains a subset of all possible
+    # facter data (see FacterDB 0.5.2 for Facter releases 3.8 and 3.9). In this situation we need to
+    # cycle through and downgrade Facter versions per platform type until we find matching Facter data.
+    filter.each do |filter_spec|
+      facter_version_filter = RspecPuppetFacts.facter_version_to_filter(facterversion)
+      db = FacterDB.get_facts(filter_spec.merge({ :facterversion =>  facter_version_filter }))
+
+      version = facterversion
+      while db.empty? && version !~ /\d+\.0($|\.\d+)/
+        version = RspecPuppetFacts.down_facter_version(version)
+        facter_version_filter = RspecPuppetFacts.facter_version_to_filter(version)
+        db = FacterDB.get_facts(filter_spec.merge({ :facterversion =>  facter_version_filter }))
+      end
+
+      next if db.empty?
+
+      unless version == facterversion
+        if RspecPuppetFacts.spec_facts_strict?
+          raise ArgumentError, "No facts were found in the FacterDB for Facter v#{facterversion}, aborting"
+        else
+          RspecPuppetFacts.warning "No facts were found in the FacterDB for Facter v#{facterversion}, using v#{version} instead"
+        end
+      end
+
+      filter_spec[:facterversion] = facter_version_filter
+    end
+
     received_facts = FacterDB::get_facts(filter)
     unless received_facts.any?
       RspecPuppetFacts.warning "No facts were found in the FacterDB for: #{filter.inspect}"
       return {}
-    end
-
-    unless version == facterversion
-      if RspecPuppetFacts.spec_facts_strict?
-        raise ArgumentError, "No facts were found in the FacterDB for Facter v#{facterversion}, aborting"
-      else
-        RspecPuppetFacts.warning "No facts were found in the FacterDB for Facter v#{facterversion}, using v#{version} instead"
-      end
     end
 
     os_facts_hash = {}

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -161,17 +161,13 @@ describe RspecPuppetFacts do
       }
 
       let(:expected_fact_sets) do
-        if Facter.version.to_f < 1.7
-          ['ubuntu-12.04-x86_64', 'ubuntu-14.04-x86_64']
-        else
-          ['ubuntu-12.04-x86_64', 'ubuntu-14.04-x86_64', 'ubuntu-16.04-x86_64']
-        end
+        ['ubuntu-12.04-x86_64', 'ubuntu-14.04-x86_64', 'ubuntu-16.04-x86_64']
       end
 
       it 'should return a hash' do
         expect(subject.class).to eq Hash
       end
-      it 'should have 4 elements' do
+      it 'should have 3 elements' do
         expect(subject.size).to eq(expected_fact_sets.size)
       end
       it 'should return supported OS' do

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -588,6 +588,36 @@ describe RspecPuppetFacts do
                                               /:facterversion must be in the /)
       end
     end
+
+    context 'Downgrades to a facter version with facts per OS' do
+      subject do
+        on_supported_os(
+          supported_os: [
+            { 'operatingsystem' => 'CentOS', 'operatingsystemrelease' => %w[7] },
+            { 'operatingsystem' => 'OpenSuSE', 'operatingsystemrelease' => %w[42] }
+          ],
+          facterversion: '3.9.5'
+        )
+      end
+
+      before(:each) do
+        allow(FacterDB).to receive(:get_facts).and_call_original
+        allow(FacterDB).to receive(:get_facts).with(
+          a_hash_including(facterversion: "/\\A3\\.9\\./", operatingsystem: 'CentOS')
+        ).and_return([])
+      end
+
+      it 'returns CentOS facts from a facter version matching 3.8' do
+        is_expected.to include(
+          'centos-7-x86_64' => include(facterversion: '3.8.0')
+        )
+      end
+      it 'returns OpenSuSE facts from a facter version matching 3.9' do
+        is_expected.to include(
+          'opensuse-42-x86_64' => include(facterversion: '3.9.2')
+        )
+      end
+    end
   end
 
   context '#add_custom_fact' do


### PR DESCRIPTION
Currently the version of Facter to use when referencing FacterDB is selected, with version downgrading if necessary, without regard to the OS. However, FacterDB contains Facter v3.9 for only a small subset of platforms so if/when 3.9 is selected (e.g. as a downgrade from Facter 3.11) most of the potential platforms aren't found.

This patch adds the facter version select/downgrade cycle on a per platform basis to find the newest matching set of facts.