### PR TITLE
Symbolize hash keys in `register_custom_fact`

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -165,7 +165,7 @@ module RspecPuppetFacts
   # @api private
   def self.register_custom_fact(name, value, options)
     @custom_facts ||= {}
-    @custom_facts[name.to_s] = {:options => options, :value => value}
+    @custom_facts[name.to_sym] = {:options => options, :value => value}
   end
 
   # Adds any custom facts according to the rules defined for the operating

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -589,24 +589,24 @@ describe RspecPuppetFacts do
 
     it 'adds a simple fact and value' do
       add_custom_fact 'root_home', '/root'
-      expect(subject['redhat-7-x86_64']['root_home']).to eq '/root'
+      expect(subject['redhat-7-x86_64'][:root_home]).to eq '/root'
     end
 
     it 'confines a fact to a particular operating system' do
       add_custom_fact 'root_home', '/root', :confine => 'redhat-7-x86_64'
-      expect(subject['redhat-7-x86_64']['root_home']).to eq '/root'
-      expect(subject['redhat-6-x86_64']['root_home']).to be_nil
+      expect(subject['redhat-7-x86_64'][:root_home]).to eq '/root'
+      expect(subject['redhat-6-x86_64'][:root_home]).to be_nil
     end
 
     it 'excludes a fact from a particular operating system' do
       add_custom_fact 'root_home', '/root', :exclude => 'redhat-7-x86_64'
-      expect(subject['redhat-7-x86_64']['root_home']).to be_nil
-      expect(subject['redhat-6-x86_64']['root_home']).to eq '/root'
+      expect(subject['redhat-7-x86_64'][:root_home]).to be_nil
+      expect(subject['redhat-6-x86_64'][:root_home]).to eq '/root'
     end
 
     it 'takes a proc as a value' do
       add_custom_fact 'root_home', ->(_os, _facts) { '/root' }
-      expect(subject['redhat-7-x86_64']['root_home']).to eq '/root'
+      expect(subject['redhat-7-x86_64'][:root_home]).to eq '/root'
     end
   end
 


### PR DESCRIPTION
This fixes issues where adding custom facts would not override existing
facts supplied by `on_supported_os`, due to rspec-puppet favoring the
symbolized keys over the string keys.
Fixes #41 