### PR TITLE
(PDK-1433) Allow specifying a default Facter version

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ describe 'myclass::debian' do
 end
 ```
 
+## Specifying a default Facter version
+
+By default, `os_supported_os` will return the facts for the version of Facter
+that it has loaded (usually this is Facter 2.5.1). This behaviour can be
+overridden by setting the `default_facter_version` RSpec setting in your
+`spec/spec_helper.rb` file.
+
+```ruby
+RSpec.configure do |c|
+  c.default_facter_version = '3.14.0'
+end
+```
+
 ## Usage
 
 Use the `on_supported_os` iterator to loop through all of your module's supported operating systems. This allows you to simplify your tests and remove a lot of duplicate code.

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -4,6 +4,10 @@ require 'facterdb'
 require 'json'
 require 'mcollective'
 
+RSpec.configure do |c|
+  c.add_setting :default_facter_version, :default => Facter.version
+end
+
 # The purpose of this module is to simplify the Puppet
 # module's RSpec tests by looping through all supported
 # OS'es and their facts data which is received from the FacterDB.
@@ -31,7 +35,7 @@ module RspecPuppetFacts
     opts[:hardwaremodels] ||= ['x86_64']
     opts[:hardwaremodels] = [opts[:hardwaremodels]] unless opts[:hardwaremodels].is_a? Array
     opts[:supported_os] ||= RspecPuppetFacts.meta_supported_os
-    opts[:facterversion] ||= Facter.version
+    opts[:facterversion] ||= RSpec.configuration.default_facter_version
 
     unless (facterversion = opts[:facterversion]) =~ /\A\d+\.\d+(?:\.\d+)*\z/
       raise ArgumentError, ":facterversion must be in the format 'n.n' or " \

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -428,9 +428,6 @@ describe RspecPuppetFacts do
     end
 
     context 'Without a custom facterversion in the options hash' do
-      before(:each) do
-        allow(Facter).to receive(:version).and_return('2.4.5')
-      end
       subject do
         on_supported_os(
           supported_os: [
@@ -440,9 +437,36 @@ describe RspecPuppetFacts do
       end
 
       it 'returns facts from the loaded facter version' do
+        facter_version = Facter.version.split('.')
         is_expected.to match(
           'centos-7-x86_64' => include(
-            facterversion: /\A2\.4\./
+            facterversion: /\A#{facter_version[0]}\.#{facter_version[1]}\./
+          )
+        )
+      end
+    end
+
+    context 'With a default Facter version specified in the RSpec configuration' do
+      before(:each) do
+        RSpec.configuration.default_facter_version = '3.1.0'
+      end
+
+      after(:each) do
+        RSpec.configuration.default_facter_version = Facter.version
+      end
+
+      subject do
+        on_supported_os(
+          supported_os: [
+            { 'operatingsystem' => 'CentOS', 'operatingsystemrelease' => %w[7] }
+          ]
+        )
+      end
+
+      it 'returns facts from the specified default Facter version' do
+        is_expected.to match(
+          'centos-7-x86_64' => include(
+            facterversion: /\A3\.1\./
           )
         )
       end


### PR DESCRIPTION
Currently the `on_supported_os` helper from rspec-puppet-facts defaults to `Facter.version` (which in most cases for gem installs is 2.5.1) and can only be overridden by passing a hash to this method each time you use it (`on_supported_os(facterversion: '3.11.0')`). While this works, its not ideal to have to do this manually in each test.