### PR TITLE
Relax Ruby requirement to >= 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ script:
 - bundle exec rake spec
 - bundle exec rake build
 rvm:
-- 2.4.5
-- 2.5.3
+- 2.4
+- 2.5
 matrix:
   fast_finish: true
+  include:
+    - rvm: 2.6
+      env: COVERAGE=true
 notifications:
   email: false
 deploy:
@@ -20,4 +23,4 @@ deploy:
     tags: true
     repo: mcanevet/rspec-puppet-facts
     all_branches: true
-    rvm: 2.5.3
+    rvm: 2.6

--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -14,17 +14,13 @@ Gem::Specification.new do |s|
   s.licenses    = 'Apache-2.0'
 
   # see .travis.yml for the supported ruby versions
-  s.required_ruby_version = '>= 2.4.5'
+  s.required_ruby_version = '>= 2.4.0'
 
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  if RUBY_VERSION =~ /^1\./
-    s.add_development_dependency 'mime-types', '< 3.0'
-  else
-    s.add_development_dependency 'mime-types'
-  end
+  s.add_development_dependency 'mime-types'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
-require 'coveralls'
-Coveralls.wear!
+if ENV['COVERAGE']
+  require 'coveralls'
+  Coveralls.wear!
+end
 
 require 'rspec'
 require 'rspec-puppet-facts'


### PR DESCRIPTION
Overrides the change in #83 which I believe only set the requirement to >= 2.4.5 because that was the lowest version of Ruby it was being tested against. I've relaxed this requirement to >= 2.4.0

Additionally, I've changed the TravisCI configuration so that test coverage is only submitted once per run.

Closes #82