### PR TITLE
Accept a single operatingsystem release as a string

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -56,7 +56,7 @@ module RspecPuppetFacts
     filter = []
     opts[:supported_os].map do |os_sup|
       if os_sup['operatingsystemrelease']
-        os_sup['operatingsystemrelease'].map do |operatingsystemmajrelease|
+        Array(os_sup['operatingsystemrelease']).map do |operatingsystemmajrelease|
           opts[:hardwaremodels].each do |hardwaremodel|
 
             os_release_filter = "/^#{operatingsystemmajrelease.split(' ')[0]}/"

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -142,6 +142,30 @@ describe RspecPuppetFacts do
       end
     end
 
+    context 'When specifying a supported_os with a single release as a String' do
+      subject(:factsets) do
+        on_supported_os(
+          {
+            :supported_os => [
+              { 'operatingsystem' => 'RedHat', 'operatingsystemrelease' => '7' },
+            ]
+          }
+        )
+      end
+
+      it 'returns a Hash' do
+        expect(factsets).to be_a(Hash)
+      end
+
+      it 'returns a single fact set' do
+        expect(factsets.size).to eq(1)
+      end
+
+      it 'returns a fact set for the specified release' do
+        expect(factsets).to include('redhat-7-x86_64' => include(:operatingsystemmajrelease => '7'))
+      end
+    end
+
     context 'When testing Ubuntu' do
       subject {
         on_supported_os(


### PR DESCRIPTION
So that if you're filtering a single release, you don't have to specify it as a single value array.

```ruby
on_supported_os({
  :supported_os => [ {
    'operatingsystem' => 'RedHat',
    'operatingsystemrelease' => '5',
  } ]
}).each do ...
```

Fixes #6