### PR TITLE
Make the mcollective fact (mco_version) optional

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -2,7 +2,6 @@ require 'puppet'
 require 'facter'
 require 'facterdb'
 require 'json'
-require 'mcollective'
 
 RSpec.configure do |c|
   c.add_setting :default_facter_version, :default => Facter.version
@@ -237,11 +236,12 @@ module RspecPuppetFacts
   def self.common_facts
     return @common_facts if @common_facts
     @common_facts = {
-      'mco_version'   => MCollective::VERSION,
       'puppetversion' => Puppet.version,
       'rubysitedir'   => RbConfig::CONFIG['sitelibdir'],
       'rubyversion'   => RUBY_VERSION,
     }
+
+    @common_facts['mco_version'] = MCollective::VERSION if mcollective?
 
     if augeas?
       @common_facts['augeasversion'] = Augeas.open(nil, nil, Augeas::NO_MODL_AUTOLOAD).get('/augeas/version')
@@ -253,6 +253,7 @@ module RspecPuppetFacts
   # Determine if the Augeas gem is available.
   # @api private
   # @return [Boolean] true if the augeas gem could be loaded.
+  # :nocov:
   def self.augeas?
     require 'augeas'
     true
@@ -260,6 +261,19 @@ module RspecPuppetFacts
     RspecPuppetFacts.warning "Failed to retrieve Augeas version: #{e}"
     false
   end
+  # :nocov:
+
+  # Determine if the mcollective gem is available
+  # @api private
+  # @return [Boolean] true if the mcollective gem could be loaded.
+  # :nocov:
+  def self.mcollective?
+    require 'mcollective'
+    true
+  rescue LoadError
+    false
+  end
+  # :nocov:
 
   # Get the "operatingsystem_support" structure from
   # the parsed metadata.json file

--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -33,5 +33,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'facter'
   s.add_runtime_dependency 'facterdb', '>= 0.5.0'
-  s.add_runtime_dependency 'mcollective-client'
 end

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -717,6 +717,33 @@ describe RspecPuppetFacts do
     it 'can output a warning message' do
       expect { RspecPuppetFacts.warning('test') }.to output(/test/).to_stderr_from_any_process
     end
+
+    context 'when mcollective is available' do
+      module MCollective_stub
+        VERSION = 'my_version'
+      end
+
+      before(:each) do
+        allow(described_class).to receive(:mcollective?).and_return(true)
+        stub_const('MCollective', MCollective_stub)
+        described_class.reset
+      end
+
+      it 'includes an "mco_version" fact' do
+        expect(subject.common_facts).to include('mco_version' => 'my_version')
+      end
+    end
+
+    context 'when mcollective is not available' do
+      before(:each) do
+        allow(described_class).to receive(:mcollective?).and_return(false)
+        described_class.reset
+      end
+
+      it 'does not include an "mco_version" fact' do
+        expect(subject.common_facts).not_to include('mco_version')
+      end
+    end
   end
 
   describe '.facter_version_to_filter' do

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -162,7 +162,7 @@ describe RspecPuppetFacts do
       end
 
       it 'returns a fact set for the specified release' do
-        expect(factsets).to include('redhat-7-x86_64' => include(:operatingsystemmajrelease => '7'))
+        expect(factsets).to include('redhat-7-x86_64' => include('operatingsystemmajrelease' => '7'))
       end
     end
 

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -440,10 +440,7 @@ describe RspecPuppetFacts do
         expect(subject.size).to eq 2
       end
       it 'should return supported OS' do
-        expect(subject.keys.sort).to eq %w(
-          archlinux-3-x86_64
-          debian-8-x86_64
-        )
+        expect(subject.keys.sort).to include(a_string_matching(/\Aarchlinux-\d+-x86_64/), 'debian-8-x86_64')
       end
     end
 


### PR DESCRIPTION
Similar to how the Augeas fact is only added if Augeas is available, we should only add the mcollective fact if mcollective is available.

Fixes #60