### PR TITLE
Restore Ruby >= 2.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ script:
 - bundle exec rake spec
 - bundle exec rake build
 rvm:
+- 2.1
+- 2.2
+- 2.3
 - 2.4
 - 2.5
 matrix:

--- a/rspec-puppet-facts.gemspec
+++ b/rspec-puppet-facts.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.licenses    = 'Apache-2.0'
 
   # see .travis.yml for the supported ruby versions
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
As discussed with @ghoneycutt, I'm going to temporarily maintain a `1.x` release branch that will retain Ruby >= 2.1 support for as long as PDK supports Ruby 2.1. Changes to `master` will be backported here and released as rspec-puppet-facts 1.y.z.