### PR TITLE
Bump master to 2.0.0

### DIFF
--- a/lib/rspec-puppet-facts/version.rb
+++ b/lib/rspec-puppet-facts/version.rb
@@ -2,6 +2,6 @@ module RspecPuppetFacts
   # This module contains the current version constant
   module Version
     # The current version of this gem
-    STRING = '1.9.4'
+    STRING = '2.0.0'
   end
 end


### PR DESCRIPTION
rspec-puppet-facts 1.y.z will continue on in the `1.x` release branch. Bumping master to 2.0.0 to prevent an accidental release from `master` in the 1. major version range.