### PR TITLE
Suppress warning for missing augeas gem

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -260,8 +260,7 @@ module RspecPuppetFacts
   def self.augeas?
     require 'augeas'
     true
-  rescue LoadError => e
-    RspecPuppetFacts.warning "Failed to retrieve Augeas version: #{e}"
+  rescue LoadError
     false
   end
   # :nocov:

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -753,10 +753,6 @@ describe RspecPuppetFacts do
       expect(subject.common_facts[:augeasversion]).to eq 'my_version'
     end
 
-    it 'can output a warning message' do
-      expect { RspecPuppetFacts.warning('test') }.to output(/test/).to_stderr_from_any_process
-    end
-
     context 'when mcollective is available' do
       module MCollective_stub
         VERSION = 'my_version'


### PR DESCRIPTION
Similar to #92, augeas is already optional, but emits a warning.