### PR TITLE
Search in both directions when looking for facts

### DIFF
--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -450,7 +450,31 @@ describe RspecPuppetFacts do
       }
 
       it 'should output warning message' do
-        expect(RspecPuppetFacts).to receive(:warning).with(/No facts were found in the FacterDB/)
+        expect(RspecPuppetFacts).to receive(:warning).with(/^SKIPPING/)
+        expect(RspecPuppetFacts).to receive(:warning).with(/^No facts were found in the FacterDB for ANY of the OSes/)
+        subject
+      end
+    end
+
+    context 'When specifying one correct and one wrong supported_os' do
+      subject {
+        on_supported_os(
+          {
+            :supported_os => [
+              {
+                "operatingsystem" => "Debian",
+                "operatingsystemrelease" => [
+                  "4",
+                  "8",
+                ],
+              },
+            ]
+          }
+        )
+      }
+
+      it 'should output warning message' do
+        expect(RspecPuppetFacts).to receive(:warning).with(/^SKIPPING {:operatingsystem=>\"Debian\", :operatingsystemrelease=>\"\/\^4\/\", :hardwaremodel=>\"x86_64\"}\. Couldn't find any facts to use for this OS/)
         subject
       end
     end


### PR DESCRIPTION
The existing code only tried to downgrade the facter version when
looking for facts in FacterDB.  It could also get stuck doing this if
`facterversion` was given without a `revision` part.

With this commit, if the given facterversion contains no facts for the
specific OS, it will try to find the closest facter version present in
FacterDB.  It will try up to 5 versions in each direction (starting by
downgrading the version).

Warning messages are also tweaked to make it more obvious which facts
being requested were missing and which OSes are not going to be tested
etc.

Fixes #100