### PR TITLE
Fix `down_facter_version` and regex

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -109,7 +109,7 @@ module RspecPuppetFacts
       db = FacterDB.get_facts(filter_spec.merge({ :facterversion =>  facter_version_filter }))
 
       version = facterversion
-      while db.empty? && version !~ /\d+\.0($|\.\d+)/
+      while db.empty? && version !~ /\A\d+\.0($|\.\d+)/
         version = RspecPuppetFacts.down_facter_version(version)
         facter_version_filter = RspecPuppetFacts.facter_version_to_filter(version)
         db = FacterDB.get_facts(filter_spec.merge({ :facterversion =>  facter_version_filter }))

--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -344,8 +344,9 @@ module RspecPuppetFacts
   # @param minor_subtractor [int] the value which to subtract by
   # @api private
   def self.down_facter_version(version, minor_subtractor = 1)
-      major, minor, z = version.split('.')
-      minor = (minor.to_i - minor_subtractor).to_s
-      "#{major}.#{minor}.#{z}"
+    major, minor, z = version.split('.')
+    z = '0' if z.nil?
+    minor = (minor.to_i - minor_subtractor).to_s
+    "#{major}.#{minor}.#{z}"
   end
 end

--- a/spec/rspec_puppet_facts_spec.rb
+++ b/spec/rspec_puppet_facts_spec.rb
@@ -850,4 +850,17 @@ describe RspecPuppetFacts do
       end
     end
   end
+
+  describe '.down_facter_version' do
+    context 'with MAJOR.MINOR.PATCH version' do
+      it 'decrements MINOR version' do
+        expect(RspecPuppetFacts.down_facter_version('3.5.5')).to eq '3.4.5'
+      end
+    end
+    context 'with MAJOR.MINOR version' do
+      it 'decrements MINOR version and sets PATCH to \'0\'' do
+        expect(RspecPuppetFacts.down_facter_version('3.5')).to eq '3.4.0'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, when called with a version number consisting of just a MAJOR
and MINOR part, the function would return a full version number with an
empty PATCH version. (eg `3.6.`)

Fixes #100