### PR TITLE
Log which facts could not be found

### DIFF
--- a/lib/rspec-puppet-facts.rb
+++ b/lib/rspec-puppet-facts.rb
@@ -94,7 +94,7 @@ module RspecPuppetFacts
 
       if db.empty?
         if RspecPuppetFacts.spec_facts_strict?
-          raise ArgumentError, "No facts were found in the FacterDB for Facter v#{facterversion}, aborting"
+          raise ArgumentError, "No facts were found in the FacterDB for Facter v#{facterversion} on #{filter_spec}, aborting"
         end
 
         facterversion_obj = Gem::Version.new(facterversion)
@@ -106,7 +106,7 @@ module RspecPuppetFacts
         facter_version_filter = "/\\A#{Regexp.escape(version)}/"
 
         unless version == facterversion
-          RspecPuppetFacts.warning "No facts were found in the FacterDB for Facter v#{facterversion}, using v#{version} instead"
+          RspecPuppetFacts.warning "No facts were found in the FacterDB for Facter v#{facterversion} on #{filter_spec}, using v#{version} instead"
         end
       end
 


### PR DESCRIPTION
It can be difficult to figure out which facts are missing. By logging the filter spec, the user can figure out which facts need to be contributed to facterdb.