### PR TITLE
CI: Dont validate puppet_agent_facter_versions.json anymore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,6 @@ jobs:
           bundler-cache: true
       - name: Run unit tests
         run: bundle exec rake spec
-      - name: Test against Puppet component versions
-        run: bundle exec rake puppet_versions:test
       - name: Test gem build
         run: gem build --strict --verbose *.gemspec
 


### PR DESCRIPTION
For a long time, we talked to the forge API to get a list of puppet-agent releases and their components. One of the components is facter. We generated a list with an agent<>facter mapping. This file lives in ext/puppet_agent_facter_versions.json.

Now that we cannot test with puppet agent from Perforce, scraping that list doesn't make sense.

From OpenVoxProject, we don't have a related API yet. So instead of switching to a different API, we disable the CI check for now.